### PR TITLE
Remove edit team name settings option

### DIFF
--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -40,15 +40,6 @@ export default function SettingsPage() {
             </Link>
           </div>
         </div>
-        <div className={classes['team-names']}>
-          <h4>Team Names</h4>
-          <div className={classes['modify-setting']}>
-            <Link to="/pool-home">
-              <p>Change players team names</p>
-              <KeyboardArrowRightIcon />
-            </Link>
-          </div>
-        </div>
         <div className={classes['reassign-teams']}>
           <h4>Reassign Teams</h4>
           <div className={classes['modify-setting']}>

--- a/src/pages/SettingsPage.module.css
+++ b/src/pages/SettingsPage.module.css
@@ -1,51 +1,50 @@
 .pool-settings {
-    width: 100%;
-    max-width: 360px;
-    padding: 1.16rem .75rem 0;
-    align-items: center;
-    flex-direction: column;
-    gap: 2rem;
+  width: 100%;
+  max-width: 360px;
+  padding: 1.16rem 0.75rem 0;
+  align-items: center;
+  flex-direction: column;
+  gap: 2rem;
 }
 
 .settings-content {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
 .league-setting,
 .manage-players,
-.team-names,
 .reassign-teams {
-    display: flex;
-    flex-direction: column;
-    gap: .5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .league-info {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 }
 
 .league-info,
-.modify-setting>a,
-.switch-container>p {
-    color: var(--secondary-text-color);
+.modify-setting > a,
+.switch-container > p {
+  color: var(--secondary-text-color);
 }
 
-.modify-setting>a {
-    text-decoration: none;
-    cursor: pointer;
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
+.modify-setting > a {
+  text-decoration: none;
+  cursor: pointer;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .switch-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: .5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
 }


### PR DESCRIPTION
Remove the option to specifically change team names because users can do this through the manage players option.