### PR TITLE
Add place to overal standings

### DIFF
--- a/src/components/PlayerWinsTracker.jsx
+++ b/src/components/PlayerWinsTracker.jsx
@@ -13,16 +13,18 @@ const getPlayerWins = (player) => {
   return wins;
 };
 
-export default function PlayerWinsTracker({ player }) {
+export default function PlayerWinsTracker({ player, standing }) {
   const playerWins = getPlayerWins(player);
 
   return (
     <div className={classes['wins-tracker-container']}>
-      <span className={classes['wins-tracker']}>{`${playerWins} Wins`}</span>
+      <p className={classes['player-standing']}>{`${standing}`}</p>
+      <p className={classes['player-wins']}>{`${playerWins} Wins`}</p>
     </div>
   );
 }
 
 PlayerWinsTracker.propTypes = {
   player: PropTypes.object.isRequired,
+  standing: PropTypes.string,
 };

--- a/src/components/PlayerWinsTracker.module.css
+++ b/src/components/PlayerWinsTracker.module.css
@@ -1,3 +1,14 @@
-.wins-tracker {
-    font-size: 1.1rem;
+.wins-tracker-container {
+  font-size: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.player-standing {
+  color: var(--secondary-text-color);
+}
+
+.player-wins {
+  font-size: 1.1rem;
 }

--- a/src/pages/PoolHomePage.jsx
+++ b/src/pages/PoolHomePage.jsx
@@ -10,6 +10,9 @@ import DesktopNavHeader from '../components/DesktopNavHeader';
 import useIsDesktop from '../utils/useIsDesktop';
 import useStoredPools from '../utils/useStoredPools';
 
+const getTotalWins = (player) =>
+  player.teams.reduce((totalWins, team) => totalWins + team.wins, 0);
+
 const sortPlayersByWins = (players) => {
   const unsortedPlayers = players.map((player) => {
     return {
@@ -18,14 +21,67 @@ const sortPlayersByWins = (players) => {
     };
   });
   const sortedPlayers = unsortedPlayers.sort((player1, player2) => {
-    const getTotalWins = (player) =>
-      player.teams.reduce((totalWins, team) => totalWins + team.wins, 0);
     const totalWinsPlayer1 = getTotalWins(player1);
     const totalWinsPlayer2 = getTotalWins(player2);
 
     return totalWinsPlayer2 - totalWinsPlayer1;
   });
   return sortedPlayers;
+};
+
+const getStandingSuffix = (standing) => {
+  const standingDigits = [...standing.toString()].map(Number);
+  const lastDigitInStanding = standingDigits[standingDigits.length - 1];
+
+  if (standing === 11 || standing === 12 || standing === 13) {
+    return 'th';
+  }
+
+  switch (lastDigitInStanding) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+};
+
+const getPlayerStandings = (sortedPlayers) => {
+  const playerStandings = [];
+  let currentStanding = 1;
+  let playerAIndex = 0;
+
+  for (let i = 0; i < sortedPlayers.length; i++) {
+    let standingSuffix = getStandingSuffix(currentStanding);
+    let playerBIndex = playerAIndex + 1;
+    let playerA = sortedPlayers[playerAIndex];
+    let playerB = sortedPlayers[playerBIndex];
+    let playerAWins = getTotalWins(playerA);
+    let playerBWins =
+      playerBIndex < sortedPlayers.length ? getTotalWins(playerB) : null;
+
+    // Compare players a and b
+    // if a > b, a receives the standing
+    if (playerAWins === playerBWins && playerBIndex < sortedPlayers.length) {
+      // if a = b, a and b are set to current standing
+      playerStandings.push(
+        { [playerA.playerName]: `${currentStanding}${standingSuffix}` },
+        { [playerB.playerName]: `${currentStanding}${standingSuffix}` },
+      );
+    } else {
+      playerStandings.push({
+        [playerA.playerName]: `${currentStanding}${standingSuffix}`,
+      });
+    }
+    // b is set to a
+    playerAIndex++;
+    // standing is set to 2
+    currentStanding++;
+  }
+  return playerStandings;
 };
 
 export default function PoolHomePage() {
@@ -36,6 +92,8 @@ export default function PoolHomePage() {
   const isDesktop = useIsDesktop();
   const { getNonActivePools } = useStoredPools();
   const nonActivePools = getNonActivePools();
+  const playerStandings = getPlayerStandings(sortedPlayers);
+  console.log(playerStandings);
 
   return (
     <div className={classes['page-container']}>

--- a/src/pages/PoolHomePage.jsx
+++ b/src/pages/PoolHomePage.jsx
@@ -50,7 +50,7 @@ const getStandingSuffix = (standing) => {
 };
 
 const getPlayerStandings = (sortedPlayers) => {
-  const playerStandings = [];
+  const playerStandings = {};
   let currentStanding = 1;
   let playerAIndex = 0;
 
@@ -67,14 +67,13 @@ const getPlayerStandings = (sortedPlayers) => {
     // if a > b, a receives the standing
     if (playerAWins === playerBWins && playerBIndex < sortedPlayers.length) {
       // if a = b, a and b are set to current standing
-      playerStandings.push(
-        { [playerA.playerName]: `${currentStanding}${standingSuffix}` },
-        { [playerB.playerName]: `${currentStanding}${standingSuffix}` },
-      );
+      playerStandings[playerA.playerName] =
+        `${currentStanding}${standingSuffix}`;
+      playerStandings[playerB.playerName] =
+        `${currentStanding}${standingSuffix}`;
     } else {
-      playerStandings.push({
-        [playerA.playerName]: `${currentStanding}${standingSuffix}`,
-      });
+      playerStandings[playerA.playerName] =
+        `${currentStanding}${standingSuffix}`;
     }
     // b is set to a
     playerAIndex++;
@@ -117,6 +116,7 @@ export default function PoolHomePage() {
         <div className={classes['pool-players']}>
           <h3>Overall Standings</h3>
           {sortedPlayers.map((player, playerIndex) => {
+            const playerStanding = playerStandings[player.playerName];
             return (
               <div key={playerIndex} className={classes['player-container']}>
                 <PlayerHomeProfile
@@ -124,7 +124,7 @@ export default function PoolHomePage() {
                   player={player}
                   playerIndex={playerIndex}
                 />
-                <PlayerWinsTracker player={player} />
+                <PlayerWinsTracker player={player} standing={playerStanding} />
               </div>
             );
           })}


### PR DESCRIPTION
Displays each player's standing (1st, 2nd, etc) above their wins total for a better UI/UX. This will make it easier to see player's current standing at a glance, especially for leagues with larger numbers of people.