### PR TITLE
Remove PoolHomePage header h3 styles

### DIFF
--- a/src/pages/PoolHomePage.module.css
+++ b/src/pages/PoolHomePage.module.css
@@ -16,12 +16,6 @@
   gap: 2rem;
 }
 
-/* Override pageHeader styling for this page because it doesn't contain any other elements */
-.pool-home div:first-child > h3 {
-  position: static;
-  transform: none;
-}
-
 .pool-players {
   width: 100%;
   display: flex;


### PR DESCRIPTION
Remove styles targeting the h3 in the PageHeader component because they're unintentionally impact the mobile header view.