### PR TITLE
Prevent empty inputs create pool

### DIFF
--- a/src/pages/CreatePoolPage.jsx
+++ b/src/pages/CreatePoolPage.jsx
@@ -4,6 +4,7 @@ import UserTextInput from '../components/UserTextInput';
 import classes from './CreatePoolPage.module.css';
 import usePool from '../utils/usePool';
 import PlayersList from '../components/PlayersList';
+import { useState, useEffect } from 'react';
 
 export default function CreatePoolPage() {
   const {
@@ -14,13 +15,25 @@ export default function CreatePoolPage() {
     handleTeamNameChange,
   } = usePool();
 
+  const [isPoolCreated, setIsPoolCreated] = useState(false);
+
+  useEffect(() => {
+    const checkPoolCreated = () => {
+      let playersHaveNames =
+        pool.players[0].playerName?.replace(/[^a-zA-z]/g, '').length > 0;
+      let poolHasName = pool.poolName?.replace(/[^a-zA-Z]/g, '').length > 0;
+      return playersHaveNames && poolHasName;
+    };
+    setIsPoolCreated(checkPoolCreated());
+  }, [pool.players, pool.poolName]);
+
   return (
     <div
       id="create-pool-container"
       className={classes['create-pool-container']}
     >
       <div className={classes['create-pool-page-header']}>
-        <NextHeaderButton path="/choose-player" />
+        <NextHeaderButton path="/choose-player" disabled={!isPoolCreated} />
         <h1>Create a pool</h1>
       </div>
       <div className={classes['choose-pool-name']}>

--- a/src/pages/PoolHomePage.jsx
+++ b/src/pages/PoolHomePage.jsx
@@ -92,7 +92,6 @@ export default function PoolHomePage() {
   const { getNonActivePools } = useStoredPools();
   const nonActivePools = getNonActivePools();
   const playerStandings = getPlayerStandings(sortedPlayers);
-  console.log(playerStandings);
 
   return (
     <div className={classes['page-container']}>

--- a/src/utils/useApiData.js
+++ b/src/utils/useApiData.js
@@ -35,7 +35,6 @@ export default function useApiData() {
       ) {
         // if yes, use data from localStorage
         data = storedData.data;
-        console.log('Using data from localStorage');
       } else {
         let url;
         switch (league) {

--- a/src/utils/usePool.js
+++ b/src/utils/usePool.js
@@ -45,7 +45,6 @@ export default function usePool() {
     // Remove possible blank players before adding to localStorage
     const cleanedPool = cleanPool(pool);
     localStorage.setItem(`pool-${cleanedPool.id}`, JSON.stringify(cleanedPool));
-    console.log('Pool cleaned and passed to storage');
   }, [pool]);
 
   useEffect(() => {


### PR DESCRIPTION
Disable the next button until a pool name and at least one player name is entered to prevent issues caused by blank strings.
User must enter some letters as only non-letter characters wouldn't be couldn't.
Remove all logs that aren't needed