### PR TITLE
Issue #134 load team records on pool home page

### DIFF
--- a/src/pages/ChoosePlayerPage.jsx
+++ b/src/pages/ChoosePlayerPage.jsx
@@ -3,6 +3,7 @@ import BackHeaderButton from '../components/BackHeaderButton';
 import NextHeaderButton from '../components/NextHeaderButton';
 import PrimaryActionButton from '../components/PrimaryActionButton';
 import classes from './ChoosePlayerPage.module.css';
+import CircularIndeterminate from '../components/Loading';
 import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { storePoolAsync, setUserId, setPool } from '../state/poolSlice';
@@ -15,6 +16,7 @@ export default function ChoosePlayerPage() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const pool = useSelector((state) => state.pool);
+  const isStoringPool = useSelector((state) => state.pool.storingPool);
   const [areTeamsSelected, setAreTeamsSelected] = useState(false);
 
   // Check if all players have teams to determine if next button should be enabled
@@ -55,11 +57,17 @@ export default function ChoosePlayerPage() {
         <NextHeaderButton path="/pool-home" disabled={!areTeamsSelected} />
       </div>
       <ChoosePlayerList />
-      <PrimaryActionButton
+      {isStoringPool ? (
+        <div className={classes['loading-container']}>
+          <CircularIndeterminate />
+        </div>
+      ) : (
+        <PrimaryActionButton
         text="Create Pool"
         handleClick={handleStorePool}
         disabled={!areTeamsSelected}
       />
+      )}
     </div>
   );
 }

--- a/src/pages/ChoosePlayerPage.jsx
+++ b/src/pages/ChoosePlayerPage.jsx
@@ -5,7 +5,7 @@ import PrimaryActionButton from '../components/PrimaryActionButton';
 import classes from './ChoosePlayerPage.module.css';
 import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { storePoolAsync, setUserId } from '../state/poolSlice';
+import { storePoolAsync, setUserId, setPool } from '../state/poolSlice';
 import { useUser, useAuth } from '@clerk/clerk-react';
 import { useNavigate } from 'react-router-dom';
 
@@ -33,8 +33,10 @@ export default function ChoosePlayerPage() {
       dispatch(setUserId(user.id));
       // Wait for the pool to be stored
       const token = await getToken();
-      const result = await dispatch(storePoolAsync({ token })).unwrap();
-      console.log('Pool stored: ', result);
+      const storedPool = await dispatch(storePoolAsync({ token })).unwrap();
+      console.log('Pool stored: ', storedPool);
+
+      dispatch(setPool(storedPool));
 
       localStorage.setItem('activePoolId', pool.id);
       localStorage.setItem('userId', user.id);

--- a/src/pages/ChoosePlayerPage.module.css
+++ b/src/pages/ChoosePlayerPage.module.css
@@ -29,3 +29,11 @@
 [class*='assign-teams-page'] > div:last-of-type {
   width: clamp(200px, 100%, 350px);
 }
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: clamp(200px, 100%, 350px);
+  height: 48px;  /* Match the height of the button */
+}

--- a/src/pages/ReassignTeamsPage.jsx
+++ b/src/pages/ReassignTeamsPage.jsx
@@ -12,6 +12,7 @@ import { useSelector } from 'react-redux';
 import { setPool, updatePoolAsync } from '../state/poolSlice';
 import { useAuth } from '@clerk/clerk-react';
 import { useDispatch } from 'react-redux';
+import { fetchCompletePool } from '../services/poolService';
 
 export default function ReassignTeamsPage() {
   const { getToken } = useAuth();
@@ -28,10 +29,15 @@ export default function ReassignTeamsPage() {
   const handleUpdateTeams = async () => {
     try {
       console.log('Storing pool: ', updatingPool);
-
       const token = await getToken();
-      const updatedPool = await dispatch(updatePoolAsync({ token })).unwrap();
+
+      // First update the pool in the database
+      await dispatch(updatePoolAsync({ token })).unwrap();
+
+      // Then fetch the complete pool with team data
+      const updatedPool = await fetchCompletePool(pool.id, token);
       dispatch(setPool(updatedPool));
+
       console.log('Finished storing pool: ', updatingPool);
     } catch (error) {
       console.error('Error updating teams: ', error);

--- a/src/pages/ReassignTeamsPage.jsx
+++ b/src/pages/ReassignTeamsPage.jsx
@@ -4,9 +4,10 @@ import PageHeader from '../components/PageHeader';
 import MobileNavMenu from '../components/MobileNavMenu';
 import PlayerHomeProfile from '../components/PlayerHomeProfile';
 import TeamsList from '../components/TeamsList';
-import { Fragment, useState } from 'react';
 import useIsDesktop from '../utils/useIsDesktop';
 import DesktopNavHeader from '../components/DesktopNavHeader';
+import CircularIndeterminate from '../components/Loading';
+import { Fragment, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { setPool, updatePoolAsync } from '../state/poolSlice';
 import { useAuth } from '@clerk/clerk-react';
@@ -16,6 +17,7 @@ export default function ReassignTeamsPage() {
   const { getToken } = useAuth();
   const dispatch = useDispatch();
   const pool = useSelector((state) => state.pool);
+  const updatingPool = useSelector((state) => state.pool.loading);
   const [playerToEdit, setPlayerToEdit] = useState(null);
   const isDesktop = useIsDesktop();
 
@@ -23,22 +25,24 @@ export default function ReassignTeamsPage() {
     setPlayerToEdit((prevIndex) => (prevIndex === index ? null : index));
   };
 
-  const handleUpdateTeams = async () => {    
+  const handleUpdateTeams = async () => {
     try {
+      console.log('Storing pool: ', updatingPool);
+
       const token = await getToken();
-      await dispatch(updatePoolAsync({ token })).unwrap();
+      const updatedPool = await dispatch(updatePoolAsync({ token })).unwrap();
+      dispatch(setPool(updatedPool));
+      console.log('Finished storing pool: ', updatingPool);
     } catch (error) {
       console.error('Error updating teams: ', error);
     } finally {
       setPlayerToEdit(null);
     }
-  }
+  };
 
   return (
     <div className={classes['page-container']}>
-      {isDesktop && (
-        <DesktopNavHeader />
-      )}
+      {isDesktop && <DesktopNavHeader />}
       <div className={classes['reassign-teams']}>
         <PageHeader
           headerText="Rassign Teams"
@@ -55,12 +59,22 @@ export default function ReassignTeamsPage() {
                   <PlayerHomeProfile player={player} playerIndex={index} />
                   <button
                     className={classes['edit-btn']}
-                    onClick={playerToEdit !== null ? handleUpdateTeams : () => togglePlayerToEdit(index)}
+                    onClick={
+                      playerToEdit !== null
+                        ? handleUpdateTeams
+                        : () => togglePlayerToEdit(index)
+                    }
+                    disabled={updatingPool}
                   >
                     {playerToEdit === index ? 'Save' : 'Edit'}
                   </button>
                 </div>
-                {playerToEdit === index && (
+                {updatingPool && playerToEdit === index && (
+                  <div className={classes['loading-container']}>
+                    <CircularIndeterminate />
+                  </div>
+                )}
+                {playerToEdit === index && !updatingPool && (
                   <TeamsList
                     pool={pool}
                     setPool={setPool}

--- a/src/pages/ReassignTeamsPage.module.css
+++ b/src/pages/ReassignTeamsPage.module.css
@@ -49,3 +49,12 @@
 .edit-btn:active {
   opacity: 0.7;
 }
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+  width: 100%;
+  padding: 20px;
+}

--- a/src/state/poolSlice.jsx
+++ b/src/state/poolSlice.jsx
@@ -259,9 +259,9 @@ const poolSlice = createSlice({
         state.loading = false;
         state.error = null;
       })
-      .addCase(updatePoolAsync.rejected, (state) => {
+      .addCase(updatePoolAsync.rejected, (state, action) => {
         state.loading = false;
-        state.error = true;
+        state.error = action.error.message;
       });
   },
 });

--- a/src/state/poolSlice.jsx
+++ b/src/state/poolSlice.jsx
@@ -24,6 +24,8 @@ const initialState = {
   ],
   name: '',
   userId: '',
+  storingPool: false,
+  error: null,
 };
 
 export const storePoolAsync = createAsyncThunk(
@@ -192,15 +194,15 @@ const poolSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(storePoolAsync.pending, (state) => {
-        state.loading = true;
+        state.storingPool = true;
         state.error = null;
       })
       .addCase(storePoolAsync.fulfilled, (state) => {
-        state.loading = false;
+        state.storingPool = false;
         state.error = null;
       })
       .addCase(storePoolAsync.rejected, (state, action) => {
-        state.loading = false;
+        state.storingPool = false;
         state.error = action.error.message;
       })
       .addCase(fetchPoolByIdAsync.pending, (state) => {

--- a/src/state/poolSlice.jsx
+++ b/src/state/poolSlice.jsx
@@ -262,7 +262,7 @@ const poolSlice = createSlice({
       .addCase(updatePoolAsync.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error.message;
-      });
+      })
   },
 });
 


### PR DESCRIPTION
Add team data to the pool during pool creation so that when the pool home page loads players standings can be calculated and displayed.
Displays a loading indicator when pool is being created.
Update team data properly when a player's teams are modified, and display a loading indicator while changes are being processed.