### PR TITLE
Fix hidden player in standings & remove next button from ChoosePlayerPage

### DIFF
--- a/src/pages/ChoosePlayerPage.jsx
+++ b/src/pages/ChoosePlayerPage.jsx
@@ -55,7 +55,6 @@ export default function ChoosePlayerPage() {
       <div className={classes['assign-teams-page-header']}>
         <BackHeaderButton path="/create-pool" />
         <h2>Assign Teams</h2>
-        <NextHeaderButton path="/pool-home" disabled={!areTeamsSelected} />
       </div>
       <ChoosePlayerList />
         <PrimaryActionButton

--- a/src/pages/PoolHomePage.module.css
+++ b/src/pages/PoolHomePage.module.css
@@ -30,6 +30,12 @@
   gap: 1.5rem;
 }
 
+@media (max-width: 768px) {
+  .pool-players {
+    margin-bottom: 80px;
+  }
+}
+
 .pool-home > h3 {
   margin-right: auto;
 }


### PR DESCRIPTION
Make the last player in the pool standings list visible when the mobile nav is showing.
Remove the next button from the Choose Player page so that the user has to select the Create Pool button to store their pool and properly setup their pool. 