### PR TITLE
Issue #141 add user menu to remaining pages

### DIFF
--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -17,7 +17,7 @@ export default function PageHeader(props) {
       <button className={classes['right-header-btn']}>
         {props.rightBtnText}
       </button>
-      {props.poolName && !isDesktop && (
+      {!isDesktop && (
         <UserMenu />
       )}
     </div>

--- a/src/pages/PoolHomePage.module.css
+++ b/src/pages/PoolHomePage.module.css
@@ -41,6 +41,7 @@
 }
 
 .player-container {
+  padding-bottom: 1rem;
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
Display the UserMenu whenever the PageHeader is displayed.
Update standings list layout to add space between the bottom and the edge of the browser window.